### PR TITLE
Enfore joint limits

### DIFF
--- a/axially_symmetric_controllers/CMakeLists.txt
+++ b/axially_symmetric_controllers/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Eigen3 REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(controller_interface REQUIRED)
+find_package(joint_limits REQUIRED)
 find_package(generate_parameter_library REQUIRED)
 find_package(realtime_tools REQUIRED)
 find_package(taskspace_control_msgs REQUIRED)
@@ -44,6 +45,7 @@ ament_target_dependencies(${PROJECT_NAME}
   kdl_parser
   pluginlib
   controller_interface
+  joint_limits
   realtime_tools
   taskspace_controllers
   task_priority_controllers
@@ -84,6 +86,7 @@ ament_export_dependencies(
   kdl_parser
   pluginlib
   controller_interface
+  joint_limits
   realtime_tools
   taskspace_controllers
   task_priority_controllers

--- a/axially_symmetric_controllers/src/nullspace_controller.cpp
+++ b/axially_symmetric_controllers/src/nullspace_controller.cpp
@@ -65,11 +65,10 @@ controller_interface::return_type NullspaceController::update(
   static ctrl::MatrixND I = ctrl::MatrixND::Identity(n_joints_, n_joints_);
   ctrl::VectorND joint_cmd = J_pinv * cart_cmd + (I - J_pinv * J) * h;
 
-  ctrl::VectorND new_position =
-      joint_state_.q.data + (joint_cmd * period.seconds());
-
-  auto cmd = ctrl::transformEigenToKDL(new_position, joint_cmd);
+  KDL::JntArray q_cmd = ctrl::transformEigenToKDL(joint_cmd);
+  auto cmd = create_command(joint_state_.q, q_cmd, period.seconds());
   write_command(cmd);
+
   return controller_interface::return_type::OK;
 }
 

--- a/axially_symmetric_controllers/src/twist_decomposition_controller.cpp
+++ b/axially_symmetric_controllers/src/twist_decomposition_controller.cpp
@@ -77,11 +77,10 @@ controller_interface::return_type TwistDecompositionController::update(
 
   ctrl::VectorND joint_cmd = J_pinv * mod_cart_cmd;
 
-  ctrl::VectorND new_position =
-      joint_state_.q.data + (joint_cmd * period.seconds());
-
-  auto cmd = ctrl::transformEigenToKDL(new_position, joint_cmd);
+  KDL::JntArray q_cmd = ctrl::transformEigenToKDL(joint_cmd);
+  auto cmd = create_command(joint_state_.q, q_cmd, period.seconds());
   write_command(cmd);
+
   return controller_interface::return_type::OK;
 }
 

--- a/task_priority_controllers/CMakeLists.txt
+++ b/task_priority_controllers/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Eigen3 REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(controller_interface REQUIRED)
+find_package(joint_limits REQUIRED)
 find_package(generate_parameter_library REQUIRED)
 find_package(realtime_tools REQUIRED)
 find_package(taskspace_control_msgs REQUIRED)
@@ -64,6 +65,7 @@ ament_target_dependencies(rr_objectives
   kdl_parser
   pluginlib
   controller_interface
+  joint_limits
   realtime_tools
   taskspace_control_msgs
   taskspace_controllers
@@ -89,6 +91,7 @@ ament_target_dependencies(${PROJECT_NAME}
   kdl_parser
   pluginlib
   controller_interface
+  joint_limits
   realtime_tools
   taskspace_control_msgs
   taskspace_controllers
@@ -134,6 +137,7 @@ ament_export_dependencies(
   kdl_parser
   pluginlib
   controller_interface
+  joint_limits
   generate_parameter_library
   realtime_tools
   taskspace_control_msgs

--- a/task_priority_controllers/include/task_priority_controllers/objectives/avoid_joint_limits.hpp
+++ b/task_priority_controllers/include/task_priority_controllers/objectives/avoid_joint_limits.hpp
@@ -25,10 +25,11 @@ class AvoidJointLimits : public RRObjective
 public:
   AvoidJointLimits() = default;
 
-  virtual bool init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-                    const KDL::Chain& chain,
-                    const KDL::JntArray& upper_pos_limits,
-                    const KDL::JntArray& lower_pos_limits) override;
+  virtual bool
+  init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
+       const KDL::Chain& chain,
+       const std::vector<ctrl::JointLimits>& joint_limits) override;
+
   virtual ctrl::VectorND
   getJointControlCmd(const KDL::JntArrayVel& joint_state) override;
 

--- a/task_priority_controllers/include/task_priority_controllers/objectives/avoid_joint_limits.hpp
+++ b/task_priority_controllers/include/task_priority_controllers/objectives/avoid_joint_limits.hpp
@@ -28,7 +28,7 @@ public:
   virtual bool
   init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
        const KDL::Chain& chain,
-       const std::vector<ctrl::JointLimits>& joint_limits) override;
+       const std::vector<joint_limits::JointLimits>& joint_limits) override;
 
   virtual ctrl::VectorND
   getJointControlCmd(const KDL::JntArrayVel& joint_state) override;

--- a/task_priority_controllers/include/task_priority_controllers/objectives/match_configuration.hpp
+++ b/task_priority_controllers/include/task_priority_controllers/objectives/match_configuration.hpp
@@ -28,7 +28,7 @@ public:
   virtual bool
   init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
        const KDL::Chain& chain,
-       const std::vector<ctrl::JointLimits>& joint_limits) override;
+       const std::vector<joint_limits::JointLimits>& joint_limits) override;
 
   virtual ctrl::VectorND
   getJointControlCmd(const KDL::JntArrayVel& joint_state) override;

--- a/task_priority_controllers/include/task_priority_controllers/objectives/match_configuration.hpp
+++ b/task_priority_controllers/include/task_priority_controllers/objectives/match_configuration.hpp
@@ -25,10 +25,11 @@ class MatchConfiguration : public RRObjective
 public:
   MatchConfiguration() = default;
 
-  virtual bool init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-                    const KDL::Chain& chain,
-                    const KDL::JntArray& upper_pos_limits,
-                    const KDL::JntArray& lower_pos_limits) override;
+  virtual bool
+  init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
+       const KDL::Chain& chain,
+       const std::vector<ctrl::JointLimits>& joint_limits) override;
+
   virtual ctrl::VectorND
   getJointControlCmd(const KDL::JntArrayVel& joint_state) override;
 

--- a/task_priority_controllers/include/task_priority_controllers/objectives/maximize_manipulability.hpp
+++ b/task_priority_controllers/include/task_priority_controllers/objectives/maximize_manipulability.hpp
@@ -33,7 +33,7 @@ public:
   virtual bool
   init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
        const KDL::Chain& chain,
-       const std::vector<ctrl::JointLimits>& joint_limits) override;
+       const std::vector<joint_limits::JointLimits>& joint_limits) override;
 
   virtual ctrl::VectorND
   getJointControlCmd(const KDL::JntArrayVel& joint_state) override;

--- a/task_priority_controllers/include/task_priority_controllers/objectives/maximize_manipulability.hpp
+++ b/task_priority_controllers/include/task_priority_controllers/objectives/maximize_manipulability.hpp
@@ -30,10 +30,11 @@ class MaximizeManipulability : public RRObjective
 public:
   MaximizeManipulability() = default;
 
-  virtual bool init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-                    const KDL::Chain& chain,
-                    const KDL::JntArray& upper_pos_limits,
-                    const KDL::JntArray& lower_pos_limits) override;
+  virtual bool
+  init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
+       const KDL::Chain& chain,
+       const std::vector<ctrl::JointLimits>& joint_limits) override;
+
   virtual ctrl::VectorND
   getJointControlCmd(const KDL::JntArrayVel& joint_state) override;
 

--- a/task_priority_controllers/include/task_priority_controllers/objectives/objective_plugin.hpp
+++ b/task_priority_controllers/include/task_priority_controllers/objectives/objective_plugin.hpp
@@ -30,8 +30,7 @@ public:
 
   virtual bool init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
                     const KDL::Chain& chain,
-                    const KDL::JntArray& upper_pos_limits,
-                    const KDL::JntArray& lower_pos_limits);
+                    const std::vector<ctrl::JointLimits>& joint_limits);
 
   virtual ctrl::VectorND
   getJointControlCmd(const KDL::JntArrayVel& joint_state) = 0;
@@ -40,8 +39,7 @@ protected:
   unsigned int n_joints_;
   KDL::Chain robot_chain_;
 
-  KDL::JntArray upper_pos_limits_;
-  KDL::JntArray lower_pos_limits_;
+  std::vector<ctrl::JointLimits> joint_limits_;
 };
 
 }  // namespace task_priority_controllers

--- a/task_priority_controllers/include/task_priority_controllers/objectives/objective_plugin.hpp
+++ b/task_priority_controllers/include/task_priority_controllers/objectives/objective_plugin.hpp
@@ -19,6 +19,8 @@
 #include <kdl/chain.hpp>
 #include <kdl/jntarrayvel.hpp>
 
+#include "joint_limits/joint_limits.hpp"
+
 #include "taskspace_controllers/utility.hpp"
 
 namespace task_priority_controllers
@@ -30,7 +32,7 @@ public:
 
   virtual bool init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
                     const KDL::Chain& chain,
-                    const std::vector<ctrl::JointLimits>& joint_limits);
+                    const std::vector<joint_limits::JointLimits>& joint_limits);
 
   virtual ctrl::VectorND
   getJointControlCmd(const KDL::JntArrayVel& joint_state) = 0;
@@ -39,7 +41,7 @@ protected:
   unsigned int n_joints_;
   KDL::Chain robot_chain_;
 
-  std::vector<ctrl::JointLimits> joint_limits_;
+  std::vector<joint_limits::JointLimits> joint_limits_;
 };
 
 }  // namespace task_priority_controllers

--- a/task_priority_controllers/package.xml
+++ b/task_priority_controllers/package.xml
@@ -14,6 +14,7 @@
   <depend>pluginlib</depend>
   <depend>hardware_interface</depend>
   <depend>controller_interface</depend>
+  <depend>joint_limits</depend>
   <depend>generate_parameter_library</depend>
   <depend>realtime_tools</depend>
   <depend>taskspace_control_msgs</depend>

--- a/task_priority_controllers/src/objectives/avoid_joint_limits.cpp
+++ b/task_priority_controllers/src/objectives/avoid_joint_limits.cpp
@@ -20,15 +20,25 @@ namespace task_priority_controllers
 
 bool AvoidJointLimits::init(
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-    const KDL::Chain& chain, const KDL::JntArray& upper_pos_limits,
-    const KDL::JntArray& lower_pos_limits)
+    const KDL::Chain& chain, const std::vector<ctrl::JointLimits>& joint_limits)
 {
-  if (!RRObjective::init(node, chain, upper_pos_limits, lower_pos_limits))
+  if (!RRObjective::init(node, chain, joint_limits))
   {
     return false;
   }
 
-  limits_avg.data = (upper_pos_limits.data + lower_pos_limits.data) / 2;
+  for (size_t i = 0; i < n_joints_; ++i)
+  {
+    const auto& limits = joint_limits[i];
+    if (std::isnan(limits.min_position) || std::isnan(limits.max_position))
+    {
+      RCLCPP_ERROR(node->get_logger(),
+                   "Joint at index %lu has invalid position limits (NaN).", i);
+      return false;
+    }
+
+    limits_avg(i) = 0.5 * (limits.min_position + limits.max_position);
+  }
 
   try
   {

--- a/task_priority_controllers/src/objectives/avoid_joint_limits.cpp
+++ b/task_priority_controllers/src/objectives/avoid_joint_limits.cpp
@@ -20,7 +20,8 @@ namespace task_priority_controllers
 
 bool AvoidJointLimits::init(
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-    const KDL::Chain& chain, const std::vector<ctrl::JointLimits>& joint_limits)
+    const KDL::Chain& chain,
+    const std::vector<joint_limits::JointLimits>& joint_limits)
 {
   if (!RRObjective::init(node, chain, joint_limits))
   {

--- a/task_priority_controllers/src/objectives/match_configuration.cpp
+++ b/task_priority_controllers/src/objectives/match_configuration.cpp
@@ -21,10 +21,9 @@ const static std::string CONFIG_PARAM = "match_config";
 
 bool MatchConfiguration::init(
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-    const KDL::Chain& chain, const KDL::JntArray& upper_pos_limits,
-    const KDL::JntArray& lower_pos_limits)
+    const KDL::Chain& chain, const std::vector<ctrl::JointLimits>& joint_limits)
 {
-  if (!RRObjective::init(node, chain, upper_pos_limits, lower_pos_limits))
+  if (!RRObjective::init(node, chain, joint_limits))
   {
     return false;
   }

--- a/task_priority_controllers/src/objectives/match_configuration.cpp
+++ b/task_priority_controllers/src/objectives/match_configuration.cpp
@@ -21,7 +21,8 @@ const static std::string CONFIG_PARAM = "match_config";
 
 bool MatchConfiguration::init(
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-    const KDL::Chain& chain, const std::vector<ctrl::JointLimits>& joint_limits)
+    const KDL::Chain& chain,
+    const std::vector<joint_limits::JointLimits>& joint_limits)
 {
   if (!RRObjective::init(node, chain, joint_limits))
   {

--- a/task_priority_controllers/src/objectives/maximize_manipulability.cpp
+++ b/task_priority_controllers/src/objectives/maximize_manipulability.cpp
@@ -22,7 +22,8 @@ static double MANIP_THRESHOLD = 1e-10;
 
 bool MaximizeManipulability::init(
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-    const KDL::Chain& chain, const std::vector<ctrl::JointLimits>& joint_limits)
+    const KDL::Chain& chain,
+    const std::vector<joint_limits::JointLimits>& joint_limits)
 {
   if (!RRObjective::init(node, chain, joint_limits))
   {

--- a/task_priority_controllers/src/objectives/maximize_manipulability.cpp
+++ b/task_priority_controllers/src/objectives/maximize_manipulability.cpp
@@ -22,10 +22,9 @@ static double MANIP_THRESHOLD = 1e-10;
 
 bool MaximizeManipulability::init(
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-    const KDL::Chain& chain, const KDL::JntArray& upper_pos_limits,
-    const KDL::JntArray& lower_pos_limits)
+    const KDL::Chain& chain, const std::vector<ctrl::JointLimits>& joint_limits)
 {
-  if (!RRObjective::init(node, chain, upper_pos_limits, lower_pos_limits))
+  if (!RRObjective::init(node, chain, joint_limits))
   {
     return false;
   }

--- a/task_priority_controllers/src/objectives/objective_plugin.cpp
+++ b/task_priority_controllers/src/objectives/objective_plugin.cpp
@@ -19,14 +19,12 @@ namespace task_priority_controllers
 
 bool RRObjective::init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
                        const KDL::Chain& chain,
-                       const KDL::JntArray& upper_pos_limits,
-                       const KDL::JntArray& lower_pos_limits)
+                       const std::vector<ctrl::JointLimits>& joint_limits)
 {
   robot_chain_ = chain;
   n_joints_ = robot_chain_.getNrOfJoints();
 
-  upper_pos_limits_ = upper_pos_limits;
-  lower_pos_limits_ = lower_pos_limits;
+  joint_limits_ = joint_limits;
   return true;
 }
 

--- a/task_priority_controllers/src/objectives/objective_plugin.cpp
+++ b/task_priority_controllers/src/objectives/objective_plugin.cpp
@@ -17,9 +17,10 @@
 namespace task_priority_controllers
 {
 
-bool RRObjective::init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-                       const KDL::Chain& chain,
-                       const std::vector<ctrl::JointLimits>& joint_limits)
+bool RRObjective::init(
+    std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
+    const KDL::Chain& chain,
+    const std::vector<joint_limits::JointLimits>& joint_limits)
 {
   robot_chain_ = chain;
   n_joints_ = robot_chain_.getNrOfJoints();

--- a/task_priority_controllers/src/pose_controller.cpp
+++ b/task_priority_controllers/src/pose_controller.cpp
@@ -99,11 +99,10 @@ controller_interface::return_type PoseController::update(
   ctrl::MatrixND J_pinv = ctrl::rightPinv(jac.data);
   ctrl::VectorND joint_cmd = J_pinv * cart_cmd + (I - J_pinv * jac.data) * h;
 
-  ctrl::VectorND new_position =
-      joint_state_.q.data + (joint_cmd * period.seconds());
-
-  auto cmd = ctrl::transformEigenToKDL(new_position, joint_cmd);
+  KDL::JntArray q_cmd = ctrl::transformEigenToKDL(joint_cmd);
+  auto cmd = create_command(joint_state_.q, q_cmd, period.seconds());
   write_command(cmd);
+
   return controller_interface::return_type::OK;
 }
 

--- a/task_priority_controllers/src/task_priority_controller.cpp
+++ b/task_priority_controllers/src/task_priority_controller.cpp
@@ -77,8 +77,7 @@ controller_interface::CallbackReturn TaskPriorityController::on_configure(
     return CallbackReturn::FAILURE;
   }
 
-  if (!rr_objective_->init(node, robot_chain_, upper_pos_limits_,
-                           lower_pos_limits_))
+  if (!rr_objective_->init(node, robot_chain_, joint_limits_))
   {
     RCLCPP_ERROR(node->get_logger(),
                  "Failed to initialize redundancy resolution objective.");

--- a/taskspace_controllers/CMakeLists.txt
+++ b/taskspace_controllers/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(Eigen3 REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(controller_interface REQUIRED)
+find_package(joint_limits REQUIRED)
 find_package(generate_parameter_library REQUIRED)
 find_package(realtime_tools REQUIRED)
 find_package(taskspace_control_msgs REQUIRED)
@@ -60,6 +61,7 @@ ament_target_dependencies(${PROJECT_NAME}
   kdl_parser
   pluginlib
   controller_interface
+  joint_limits
   realtime_tools
   taskspace_control_msgs
 )

--- a/taskspace_controllers/include/taskspace_controllers/taskspace_controller_base.hpp
+++ b/taskspace_controllers/include/taskspace_controllers/taskspace_controller_base.hpp
@@ -89,8 +89,7 @@ protected:
 
   // Kinematics
   KDL::Chain robot_chain_;
-  KDL::JntArray upper_pos_limits_;
-  KDL::JntArray lower_pos_limits_;
+  std::vector<ctrl::JointLimits> joint_limits_;
   std::unique_ptr<KDL::ChainFkSolverPos_recursive> robot_fk_solver_;
 
   // State tracking

--- a/taskspace_controllers/include/taskspace_controllers/taskspace_controller_base.hpp
+++ b/taskspace_controllers/include/taskspace_controllers/taskspace_controller_base.hpp
@@ -25,6 +25,7 @@
 #include "trajectory_msgs/msg/joint_trajectory_point.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "joint_limits/joint_limits.hpp"
 
 #include "ros2_version_config.h"
 
@@ -66,6 +67,10 @@ protected:
   void stop_motion();
   void write_command(const KDL::JntArrayVel& cmd);
 
+  // Utility functions
+  KDL::JntArrayVel create_command(const KDL::JntArray& q_current,
+                                  const KDL::JntArray& q_dot_cmd, double dt);
+
   // Callbacks
   using QueryPose = taskspace_control_msgs::srv::QueryPose;
   virtual bool queryPoseServiceCb(const std::shared_ptr<QueryPose::Request> req,
@@ -89,7 +94,7 @@ protected:
 
   // Kinematics
   KDL::Chain robot_chain_;
-  std::vector<ctrl::JointLimits> joint_limits_;
+  std::vector<joint_limits::JointLimits> joint_limits_;
   std::unique_ptr<KDL::ChainFkSolverPos_recursive> robot_fk_solver_;
 
   // State tracking

--- a/taskspace_controllers/include/taskspace_controllers/utility.hpp
+++ b/taskspace_controllers/include/taskspace_controllers/utility.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <limits>
 #include <Eigen/Dense>
 
 #include <kdl/chain.hpp>
@@ -35,6 +36,13 @@ typedef Eigen::MatrixXd MatrixND;
 typedef Eigen::Quaterniond Quaternion;
 typedef Eigen::AngleAxisd AngleAxis;
 typedef Eigen::Isometry3d Pose;
+
+struct JointLimits
+{
+  double min_position = std::numeric_limits<double>::quiet_NaN();
+  double max_position = std::numeric_limits<double>::quiet_NaN();
+  double max_velocity = std::numeric_limits<double>::quiet_NaN();
+};
 
 /**
  * @brief Find the left pseudoinverse of a matrix

--- a/taskspace_controllers/include/taskspace_controllers/utility.hpp
+++ b/taskspace_controllers/include/taskspace_controllers/utility.hpp
@@ -37,13 +37,6 @@ typedef Eigen::Quaterniond Quaternion;
 typedef Eigen::AngleAxisd AngleAxis;
 typedef Eigen::Isometry3d Pose;
 
-struct JointLimits
-{
-  double min_position = std::numeric_limits<double>::quiet_NaN();
-  double max_position = std::numeric_limits<double>::quiet_NaN();
-  double max_velocity = std::numeric_limits<double>::quiet_NaN();
-};
-
 /**
  * @brief Find the left pseudoinverse of a matrix
  *
@@ -100,6 +93,13 @@ void transformKDLToEigen(const KDL::Rotation& k,
  */
 KDL::JntArrayVel transformEigenToKDL(const ctrl::VectorND& q,
                                      const ctrl::VectorND& qdot);
+
+/**
+ * @brief Transforms an Eigen::Vector to a KDL::JntArray
+ *
+ * @param q the joint position
+ */
+KDL::JntArray transformEigenToKDL(const ctrl::VectorND& q);
 
 /**
  * @brief Determine if a list of interfaces includes a certain type

--- a/taskspace_controllers/package.xml
+++ b/taskspace_controllers/package.xml
@@ -14,6 +14,7 @@
   <depend>pluginlib</depend>
   <depend>hardware_interface</depend>
   <depend>controller_interface</depend>
+  <depend>joint_limits</depend>
   <depend>generate_parameter_library</depend>
   <depend>realtime_tools</depend>
   <depend>taskspace_control_msgs</depend>

--- a/taskspace_controllers/src/pose_controller.cpp
+++ b/taskspace_controllers/src/pose_controller.cpp
@@ -133,11 +133,11 @@ controller_interface::return_type PoseController::update(
 
   // --- Control law ---
   ctrl::VectorND joint_cmd = ctrl::rightPinv(jac.data) * cart_cmd;
-  ctrl::VectorND new_position =
-      joint_state_.q.data + (joint_cmd * period.seconds());
 
-  auto cmd = ctrl::transformEigenToKDL(new_position, joint_cmd);
+  KDL::JntArray q_cmd = ctrl::transformEigenToKDL(joint_cmd);
+  auto cmd = create_command(joint_state_.q, q_cmd, period.seconds());
   write_command(cmd);
+
   return controller_interface::return_type::OK;
 }
 

--- a/taskspace_controllers/src/taskspace_controller_base.cpp
+++ b/taskspace_controllers/src/taskspace_controller_base.cpp
@@ -130,8 +130,7 @@ controller_interface::CallbackReturn TaskspaceControllerBase::on_configure(
   has_velocity_command_interface_ = ctrl::contains_interface_type(
       params_.command_interfaces, hardware_interface::HW_IF_VELOCITY);
 
-  upper_pos_limits_.resize(n_joints_);
-  lower_pos_limits_.resize(n_joints_);
+  joint_limits_.resize(n_joints_);
   for (size_t i = 0; i < n_joints_; ++i)
   {
     const auto& jn = joint_names_[i];
@@ -141,22 +140,28 @@ controller_interface::CallbackReturn TaskspaceControllerBase::on_configure(
       RCLCPP_ERROR(logger, "Joint '%s' not found in URDF.", jn.c_str());
       return controller_interface::CallbackReturn::ERROR;
     }
+
+    ctrl::JointLimits limits;
     if (j->type == urdf::Joint::CONTINUOUS)
     {
-      upper_pos_limits_(i) = std::numeric_limits<double>::quiet_NaN();
-      lower_pos_limits_(i) = std::numeric_limits<double>::quiet_NaN();
+      // No position limits, but velocity may exist
+      if (j->limits)
+      {
+        limits.max_velocity = j->limits->velocity;
+      }
     }
     else if (j->limits)
     {
-      upper_pos_limits_(i) = j->limits->upper;
-      lower_pos_limits_(i) = j->limits->lower;
+      limits.min_position = j->limits->lower;
+      limits.max_position = j->limits->upper;
+      limits.max_velocity = j->limits->velocity;
     }
     else
     {
       RCLCPP_WARN(logger, "Joint %s has no limits; using NaN.", jn.c_str());
-      upper_pos_limits_(i) = std::numeric_limits<double>::quiet_NaN();
-      lower_pos_limits_(i) = std::numeric_limits<double>::quiet_NaN();
     }
+
+    joint_limits_[i] = limits;
   }
 
   robot_fk_solver_ =
@@ -233,20 +238,38 @@ void TaskspaceControllerBase::write_command(const KDL::JntArrayVel& cmd)
   size_t vel_ind = (has_position_command_interface_) ?
                        pos_ind + has_velocity_command_interface_ :
                        pos_ind;
+
   for (size_t joint_ind = 0; joint_ind < n_joints_; ++joint_ind)
   {
+    const auto& limits = joint_limits_[joint_ind];
+
+    double q_cmd = cmd.q(joint_ind);
+    double qdot_cmd = cmd.qdot(joint_ind);
+
+    // Clamp output command
+    if (!std::isnan(limits.min_position) && !std::isnan(limits.max_position))
+    {
+      q_cmd = std::clamp(q_cmd, limits.min_position, limits.max_position);
+    }
+    if (!std::isnan(limits.max_velocity))
+    {
+      qdot_cmd =
+          std::clamp(qdot_cmd, -limits.max_velocity, limits.max_velocity);
+    }
+
+    // Write output command to hardware
     if (has_position_command_interface_)
     {
-      command_interfaces_[pos_ind * n_joints_ + joint_ind].set_value(
-          cmd.q(joint_ind));
+      command_interfaces_[pos_ind * n_joints_ + joint_ind].set_value(q_cmd);
     }
     if (has_velocity_command_interface_)
     {
-      command_interfaces_[vel_ind * n_joints_ + joint_ind].set_value(
-          cmd.qdot(joint_ind));
+      command_interfaces_[vel_ind * n_joints_ + joint_ind].set_value(qdot_cmd);
     }
+
+    last_commanded_.q(joint_ind) = q_cmd;
+    last_commanded_.qdot(joint_ind) = qdot_cmd;
   }
-  last_commanded_ = cmd;
 }
 
 void TaskspaceControllerBase::stop_motion()

--- a/taskspace_controllers/src/taskspace_controller_base.cpp
+++ b/taskspace_controllers/src/taskspace_controller_base.cpp
@@ -14,10 +14,13 @@
 
 #include "taskspace_controllers/taskspace_controller_base.hpp"
 
+#include <algorithm>
+
 #include <kdl/tree.hpp>
 #include <kdl_parser/kdl_parser.hpp>
 
 #include "urdf/model.h"
+#include "joint_limits/joint_limits_urdf.hpp"
 
 namespace taskspace_controllers
 {
@@ -130,6 +133,7 @@ controller_interface::CallbackReturn TaskspaceControllerBase::on_configure(
   has_velocity_command_interface_ = ctrl::contains_interface_type(
       params_.command_interfaces, hardware_interface::HW_IF_VELOCITY);
 
+  // Initialize the joint limits from the urdf
   joint_limits_.resize(n_joints_);
   for (size_t i = 0; i < n_joints_; ++i)
   {
@@ -141,27 +145,7 @@ controller_interface::CallbackReturn TaskspaceControllerBase::on_configure(
       return controller_interface::CallbackReturn::ERROR;
     }
 
-    ctrl::JointLimits limits;
-    if (j->type == urdf::Joint::CONTINUOUS)
-    {
-      // No position limits, but velocity may exist
-      if (j->limits)
-      {
-        limits.max_velocity = j->limits->velocity;
-      }
-    }
-    else if (j->limits)
-    {
-      limits.min_position = j->limits->lower;
-      limits.max_position = j->limits->upper;
-      limits.max_velocity = j->limits->velocity;
-    }
-    else
-    {
-      RCLCPP_WARN(logger, "Joint %s has no limits; using NaN.", jn.c_str());
-    }
-
-    joint_limits_[i] = limits;
+    joint_limits::getJointLimits(j, joint_limits_[i]);
   }
 
   robot_fk_solver_ =
@@ -238,38 +222,20 @@ void TaskspaceControllerBase::write_command(const KDL::JntArrayVel& cmd)
   size_t vel_ind = (has_position_command_interface_) ?
                        pos_ind + has_velocity_command_interface_ :
                        pos_ind;
-
   for (size_t joint_ind = 0; joint_ind < n_joints_; ++joint_ind)
   {
-    const auto& limits = joint_limits_[joint_ind];
-
-    double q_cmd = cmd.q(joint_ind);
-    double qdot_cmd = cmd.qdot(joint_ind);
-
-    // Clamp output command
-    if (!std::isnan(limits.min_position) && !std::isnan(limits.max_position))
-    {
-      q_cmd = std::clamp(q_cmd, limits.min_position, limits.max_position);
-    }
-    if (!std::isnan(limits.max_velocity))
-    {
-      qdot_cmd =
-          std::clamp(qdot_cmd, -limits.max_velocity, limits.max_velocity);
-    }
-
-    // Write output command to hardware
     if (has_position_command_interface_)
     {
-      command_interfaces_[pos_ind * n_joints_ + joint_ind].set_value(q_cmd);
+      command_interfaces_[pos_ind * n_joints_ + joint_ind].set_value(
+          cmd.q(joint_ind));
     }
     if (has_velocity_command_interface_)
     {
-      command_interfaces_[vel_ind * n_joints_ + joint_ind].set_value(qdot_cmd);
+      command_interfaces_[vel_ind * n_joints_ + joint_ind].set_value(
+          cmd.qdot(joint_ind));
     }
-
-    last_commanded_.q(joint_ind) = q_cmd;
-    last_commanded_.qdot(joint_ind) = qdot_cmd;
   }
+  last_commanded_ = cmd;
 }
 
 void TaskspaceControllerBase::stop_motion()
@@ -287,6 +253,44 @@ void TaskspaceControllerBase::stop_motion()
       command_interfaces_[vel_ind * n_joints_ + joint_ind].set_value(0.0);
     }
   }
+}
+
+KDL::JntArrayVel TaskspaceControllerBase::create_command(
+    const KDL::JntArray& q_current, const KDL::JntArray& q_dot_cmd, double dt)
+{
+  KDL::JntArrayVel out(n_joints_);
+  for (size_t i = 0; i < n_joints_; ++i)
+  {
+    const auto& limits = joint_limits_[i];
+
+    double q = q_current(i);
+    double qdot = q_dot_cmd(i);
+
+    // Velocity saturation
+    if (!std::isnan(limits.max_velocity))
+    {
+      qdot = std::clamp(qdot, -limits.max_velocity, limits.max_velocity);
+    }
+
+    // Numerical Integration
+    double q_next = q + qdot * dt;
+
+    // Position saturation
+    if (!std::isnan(limits.min_position) && !std::isnan(limits.max_position))
+    {
+      double q_clamped =
+          std::clamp(q_next, limits.min_position, limits.max_position);
+
+      // Back-compute velocity to stay consistent
+      qdot = (q_clamped - q) / dt;
+      q_next = q_clamped;
+    }
+
+    out.q(i) = q_next;
+    out.qdot(i) = qdot;
+  }
+
+  return out;
 }
 
 bool TaskspaceControllerBase::queryPoseServiceCb(

--- a/taskspace_controllers/src/utility.cpp
+++ b/taskspace_controllers/src/utility.cpp
@@ -59,6 +59,16 @@ KDL::JntArrayVel transformEigenToKDL(const ctrl::VectorND& q,
   return out;
 }
 
+KDL::JntArray transformEigenToKDL(const ctrl::VectorND& q)
+{
+  const size_t n = q.size();
+  KDL::JntArray out(n);
+
+  Eigen::Map<Eigen::VectorXd>(out.data.data(), n) = q;
+
+  return out;
+}
+
 bool contains_interface_type(
     const std::vector<std::string>& interface_type_list,
     const std::string& interface_type)


### PR DESCRIPTION
## Enforce joint limits on controller output

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | closes #6  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Tormach ZA6 |

---

## Description of contribution in a few bullet points
- Limited the output of all `taskspace_controller` to fall within the position and velocity limits specified in the URDF

This is accomplished by:
- [x] Saturating the controller output $\dot{q}$ before numerically integrating to find the commanded joint angles $q$
- [X] Saturating the resulting joint angles within their limits

## Description of how this change was tested
- Drove the ZA6 straight down to determine if J2 would cross it's positional limit

```python
    def singularity(self):
        tf = 10
        tt = np.linspace(0, tf, int(self.hz * tf))

        p_start = np.array([0.7, 0.0, 0.25])
        p_end = np.array([0.0, 0.0, -1.0])

        f, f_dot = linear_traj(p_start, p_end, tf)
        ft, f_dott = f(tt), f_dot(tt)

        q_start = self.static_orient
        q_end = quaternion_multiply(self.static_orient, self.q_diff)

        q, _ = slerp_traj(q_start, q_end, tf, scaling=Order.FIFTH)
        qt = q(tt)

        self.path_viz.visualize_path([p_start, p_end], "base_link")

        self.movel(p_start, self.static_orient, 2)
        self.execute_path(ft, f_dott, qt)
        self.path_viz.reset()
```

The joints never exceed the specified limits.