### PR TITLE
Zero output when under manipulability threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `taskspace_control_examples` package provides an example setpoint publisher.
 Launch the demo robot system with the desired robot and controller
 
 ```sh
- ros2 launch taskspace_control_examples robot_bringup.launch.py robot_type:=robot6R controller:=pose_controller
+ros2 launch taskspace_control_examples robot_bringup.launch.py robot_type:=robot6R controller:=pose_controller
 ```
 
 ```

--- a/axially_symmetric_controllers/src/nullspace_controller.cpp
+++ b/axially_symmetric_controllers/src/nullspace_controller.cpp
@@ -32,6 +32,12 @@ controller_interface::return_type NullspaceController::update(
   KDL::Jacobian jac(n_joints_);
   robot_jacobian_solver_->JntToJac(joint_state_.q, jac);
 
+  // Safety: bail out near singularities
+  if (!check_manipulability(jac))
+  {
+    return controller_interface::return_type::OK;
+  }
+
   KDL::Frame pose_kdl;
   robot_fk_solver_->JntToCart(joint_state_.q, pose_kdl);
 

--- a/axially_symmetric_controllers/src/twist_decomposition_controller.cpp
+++ b/axially_symmetric_controllers/src/twist_decomposition_controller.cpp
@@ -32,6 +32,12 @@ controller_interface::return_type TwistDecompositionController::update(
   KDL::Jacobian jac(n_joints_);
   robot_jacobian_solver_->JntToJac(joint_state_.q, jac);
 
+  // Safety: bail out near singularities
+  if (!check_manipulability(jac))
+  {
+    return controller_interface::return_type::OK;
+  }
+
   KDL::Frame pose_kdl;
   robot_fk_solver_->JntToCart(joint_state_.q, pose_kdl);
 

--- a/task_priority_controllers/src/pose_controller.cpp
+++ b/task_priority_controllers/src/pose_controller.cpp
@@ -72,6 +72,12 @@ controller_interface::return_type PoseController::update(
   KDL::Jacobian jac(n_joints_);
   robot_jacobian_solver_->JntToJac(joint_state_.q, jac);
 
+  // Safety: bail out near singularities
+  if (!check_manipulability(jac))
+  {
+    return controller_interface::return_type::OK;
+  }
+
   KDL::Frame pose_kdl;
   robot_fk_solver_->JntToCart(joint_state_.q, pose_kdl);
 

--- a/taskspace_control_examples/taskspace_control_examples/pose_control_demo.py
+++ b/taskspace_control_examples/taskspace_control_examples/pose_control_demo.py
@@ -28,7 +28,7 @@ NODE_NAME = "pose_control_demo"
 robot_params = {
     "robot6R": {
         "orient": np.array([1.0, 0.0, 0.0, 0.0]),
-        "q_diff": np.array([0.707107, 0, 0, 0.707107]),
+        "q_diff": np.array([0.9238795, 0, 0, 0.3826834]),
     },
     "robot7R": {
         "orient": np.array([0.5, 0.5, 0.5, -0.5]),
@@ -84,7 +84,7 @@ class PoseControlDemo(ControlDemo):
         tt = np.linspace(0, tf, int(self.hz * tf))
         f, f_dot = circular_traj(1 / 6, tf)
 
-        offset = np.array([0.5, 0.0, 0.1])
+        offset = np.array([0.5, 0.0, 0.0])
         ft, f_dott = f(tt) + offset, f_dot(tt)
 
         q_start = self.static_orient

--- a/taskspace_controllers/include/taskspace_controllers/taskspace_controller_base.hpp
+++ b/taskspace_controllers/include/taskspace_controllers/taskspace_controller_base.hpp
@@ -69,7 +69,11 @@ protected:
 
   // Utility functions
   KDL::JntArrayVel create_command(const KDL::JntArray& q_current,
-                                  const KDL::JntArray& q_dot_cmd, double dt);
+                                  const KDL::JntArray& q_dot_cmd,
+                                  double dt) const;
+
+  double compute_manipulability(const KDL::Jacobian& jac) const;
+  bool check_manipulability(const KDL::Jacobian& jac);
 
   // Callbacks
   using QueryPose = taskspace_control_msgs::srv::QueryPose;

--- a/taskspace_controllers/src/pose_controller.cpp
+++ b/taskspace_controllers/src/pose_controller.cpp
@@ -112,6 +112,12 @@ controller_interface::return_type PoseController::update(
   KDL::Jacobian jac(n_joints_);
   robot_jacobian_solver_->JntToJac(joint_state_.q, jac);
 
+  // Safety: bail out near singularities
+  if (!check_manipulability(jac))
+  {
+    return controller_interface::return_type::OK;
+  }
+
   KDL::Frame pose_kdl;
   robot_fk_solver_->JntToCart(joint_state_.q, pose_kdl);
 

--- a/taskspace_controllers/src/taskspace_controller_base.cpp
+++ b/taskspace_controllers/src/taskspace_controller_base.cpp
@@ -256,7 +256,8 @@ void TaskspaceControllerBase::stop_motion()
 }
 
 KDL::JntArrayVel TaskspaceControllerBase::create_command(
-    const KDL::JntArray& q_current, const KDL::JntArray& q_dot_cmd, double dt)
+    const KDL::JntArray& q_current, const KDL::JntArray& q_dot_cmd,
+    double dt) const
 {
   KDL::JntArrayVel out(n_joints_);
   for (size_t i = 0; i < n_joints_; ++i)
@@ -291,6 +292,30 @@ KDL::JntArrayVel TaskspaceControllerBase::create_command(
   }
 
   return out;
+}
+
+double
+TaskspaceControllerBase::compute_manipulability(const KDL::Jacobian& jac) const
+{
+  const auto& J = jac.data;
+  const Eigen::MatrixXd J_JT = J * J.transpose();
+  return std::sqrt(std::max(0.0, J_JT.determinant()));
+}
+
+bool TaskspaceControllerBase::check_manipulability(const KDL::Jacobian& jac)
+{
+  const double w = compute_manipulability(jac);
+  if (w < params_.manipulability_threshold)
+  {
+    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(),
+                         500 /*ms*/,
+                         "Manipulability (%.6f) below threshold (%.6f) — "
+                         "zeroing output.",
+                         w, params_.manipulability_threshold);
+    stop_motion();
+    return false;
+  }
+  return true;
 }
 
 bool TaskspaceControllerBase::queryPoseServiceCb(

--- a/taskspace_controllers/src/taskspace_controller_base_parameters.yaml
+++ b/taskspace_controllers/src/taskspace_controller_base_parameters.yaml
@@ -19,3 +19,8 @@ taskspace_controller_base:
     description: "Name of the 'tool' reference frame",
     read_only: true,
   }
+  manipulability_threshold: {
+    type: double,
+    default_value: 0.01,
+    description: "Minimum manipulability index w = sqrt(det(J*J^T)) below which output is zeroed."
+  }

--- a/taskspace_controllers/src/taskspace_controller_base_parameters.yaml
+++ b/taskspace_controllers/src/taskspace_controller_base_parameters.yaml
@@ -21,6 +21,6 @@ taskspace_controller_base:
   }
   manipulability_threshold: {
     type: double,
-    default_value: 0.01,
+    default_value: 0.001,
     description: "Minimum manipulability index w = sqrt(det(J*J^T)) below which output is zeroed."
   }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
## Avoid large/infinite velocities near singular configurations

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | closes #5  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Tormach ZA6 |

---

## Description of contribution in a few bullet points
- measures the manipulability with [Yoshikawa's manipulability index](https://journals.sagepub.com/doi/10.1177/027836498500400201)
- Zero the output velocity when a configuration is below the index

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of how this change was tested

Tested by driving the robot in the z-direction to force J4 and J6 to align.
Result: Using a `manipulability_threshold` of 0.01 forces the robot to stop.

```python
    def singularity(self):
        tf = 10
        tt = np.linspace(0, tf, int(self.hz * tf))

        p_start = np.array([0.7, 0.0, 0.25])
        p_end = np.array([0.7, 0.0, 1.0])

        f, f_dot = linear_traj(p_start, p_end, tf)
        ft, f_dott = f(tt), f_dot(tt)

        q_start = self.static_orient
        q_end = quaternion_multiply(self.static_orient, self.q_diff)

        q, _ = slerp_traj(q_start, q_end, tf, scaling=Order.FIFTH)
        qt = q(tt)

        self.path_viz.visualize_path([p_start, p_end], "base_link")

        self.movel(p_start, self.static_orient, 2)
        self.execute_path(ft, f_dott, self.static_orient)
        self.path_viz.reset()
```

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->
