### PR TITLE
Fix initialization of axially-symmetric setpoint

### DIFF
--- a/axially_symmetric_controllers/include/axially_symmetric_controllers/axially_symmetric_controller_base.hpp
+++ b/axially_symmetric_controllers/include/axially_symmetric_controllers/axially_symmetric_controller_base.hpp
@@ -31,6 +31,9 @@ public:
   virtual controller_interface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State& previous_state) override;
 
+  virtual controller_interface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State& previous_state) override;
+
 protected:
   std::shared_ptr<axially_symmetric_controller::ParamListener>
       as_param_listener_;

--- a/axially_symmetric_controllers/src/axially_symmetric_controller_base.cpp
+++ b/axially_symmetric_controllers/src/axially_symmetric_controller_base.cpp
@@ -66,6 +66,50 @@ AxiallySymmetricControllerBase::on_configure(
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
+controller_interface::CallbackReturn
+AxiallySymmetricControllerBase::on_activate(
+    const rclcpp_lifecycle::State& previous_state)
+{
+  RCLCPP_INFO(get_node()->get_logger(),
+              "Activating AxiallySymmetricController...");
+
+  // Activate base class
+  if (TaskspaceControllerBase::on_activate(previous_state) !=
+      controller_interface::CallbackReturn::SUCCESS)
+  {
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  // Initialize joint state from hardware
+  read_state_from_hardware(joint_state_);
+
+  Setpoint fk;
+  robot_fk_solver_->JntToCart(joint_state_.q, fk.pose);
+
+  // Initialize a pose with the setpoint_frame_axis_ aiming
+  // in the direction of the tool_frame_axis_
+  ctrl::Matrix3D R_fk;
+  ctrl::transformKDLToEigen(fk.pose.M, R_fk);
+  ctrl::Vector3D a_target = R_fk * tool_frame_axis_;
+  a_target.normalize();
+
+  ctrl::Vector3D a_set = setpoint_frame_axis_;
+  a_set.normalize();
+
+  ctrl::Quaternion q_align = ctrl::Quaternion::FromTwoVectors(a_set, a_target);
+
+  Eigen::AngleAxisd twist(0.0, a_target);
+  ctrl::Quaternion q_final = twist * q_align;
+  ctrl::Matrix3D R = q_final.toRotationMatrix();
+
+  Setpoint init_setpoint;
+  init_setpoint.pose.M = ctrl::transformEigenToKDL(R);
+  init_setpoint.pose.p = fk.pose.p;  // keep same position
+
+  setpoint_buffer_.writeFromNonRT(std::move(init_setpoint));
+  return CallbackReturn::SUCCESS;
+}
+
 }  // namespace axially_symmetric_controllers
 
 #include "pluginlib/class_list_macros.hpp"

--- a/taskspace_controllers/include/taskspace_controllers/utility.hpp
+++ b/taskspace_controllers/include/taskspace_controllers/utility.hpp
@@ -114,6 +114,13 @@ KDL::JntArrayVel transformEigenToKDL(const ctrl::VectorND& q,
 KDL::JntArray transformEigenToKDL(const ctrl::VectorND& q);
 
 /**
+ * @brief Transforms an Eigen::Matrix to a KDL::Rotation
+ *
+ * @param R the rotation matrix
+ */
+KDL::Rotation transformEigenToKDL(const ctrl::Matrix3D& R);
+
+/**
  * @brief Generate a joint position/velocity command with limit enforcement
  *
  * Applies velocity saturation and integrates joint velocities over the given

--- a/taskspace_controllers/src/utility.cpp
+++ b/taskspace_controllers/src/utility.cpp
@@ -76,6 +76,17 @@ KDL::JntArray transformEigenToKDL(const ctrl::VectorND& q)
   return out;
 }
 
+KDL::Rotation transformEigenToKDL(const Eigen::Matrix3d& R)
+{
+  // clang-format off
+  return KDL::Rotation(
+      R(0,0), R(0,1), R(0,2),
+      R(1,0), R(1,1), R(1,2),
+      R(2,0), R(2,1), R(2,2)
+  );
+  // clang-format on
+}
+
 KDL::JntArrayVel create_command(
     const KDL::JntArray& q_current, const KDL::JntArray& q_dot_cmd,
     const std::vector<joint_limits::JointLimits>& joint_limits, double dt)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

Initialize a setpoint that aligns the two aiming vectors specified in the parameters:
- `tool_frame_axis_`
- `setpoint_frame_axis_`
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | closes #9  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Tormach ZA6 |

---

## Description of contribution in a few bullet points
- Override the `on_activate` method for `AxiallySymmetricControllers` to have a custom initialization
- Use quaternions and axis-angles to create a pose with the aiming constraint 

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

Running the examples
```shell
ros2 launch taskspace_control_examples robot_bringup.launch.py robot_type:=robot6R controller:=as_nullspace_controller
ros2 launch taskspace_control_examples pose_control_demo.launch.py robot_type:=robot6R controller:=as_nullspace_controller
```

Running the ZA6
```shell
ros2 launch za6_control_sandbox bringup.launch.py controller:=as_nullspace_controller
ros2 launch za6_control_sandbox control_demo.launch.py controller:=as_nullspace_controller
```
with
```yaml
eef_frame_axis: [1.0, 0.0, 0.0]
setpoint_frame_axis: [1.0, 0.0, 0.0]
```

The pose no longer jerks on initialization.